### PR TITLE
Fix undefined self in update hook

### DIFF
--- a/octoprint_mmu2filamentselect/__init__.py
+++ b/octoprint_mmu2filamentselect/__init__.py
@@ -102,7 +102,7 @@ class MMU2SelectPlugin(octoprint.plugin.TemplatePlugin, octoprint.plugin.Setting
 
 	#~ Update
 
-	def get_update_information(*args, **kwargs):
+	def get_update_information(self, *args, **kwargs):
 		return dict(
 			mmu2filamentselect=dict(
 				displayName=self._plugin_name,


### PR DESCRIPTION
Found in a user's log on a different issue:

```
2019-10-22 21:21:01,702 - octoprint.plugins.softwareupdate - ERROR - Error while retrieving update information from plugin mmu2filamentselect
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/softwareupdate/__init__.py", line 127, in _get_configured_checks
    hook_checks = hook()
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_mmu2filamentselect/__init__.py", line 108, in get_update_information
    displayName=self._plugin_name,
NameError: global name 'self' is not defined
```